### PR TITLE
Fix the parsing of the timestamps

### DIFF
--- a/src/core/fs.rs
+++ b/src/core/fs.rs
@@ -22,7 +22,8 @@ impl FileSystem {
     /// Returns stat info of files to parse access/modify timestamps
     pub fn file_nix_stat(file_path: &str) -> FileStat {
         // return file stats from child process
-        let child_process = Command::new("stat")
+        let child_process = Command::new("/bin/stat")
+	    .arg("--printf='%w\n%x\n%y'")
             .arg(file_path)
             .output()
             .expect("failed to execute child process");

--- a/src/core/parsers.rs
+++ b/src/core/parsers.rs
@@ -6,12 +6,16 @@ use super::fs::FileStat;
 pub fn nix_timestamp_parser(
     timestamp_str: &str
 ) -> String {
-    timestamp_str[0..19]
+    let mut timestamp = timestamp_str
 	.to_string()
 	.replace("-", "")
 	.replace(":", "")
 	.replace(" ", "")
-	.replace("'", "")
+	.replace("'", "");
+    timestamp = timestamp[0..14].to_string();
+
+    //YYYYMMDDhhmm.ss
+    format!("{}{}{}", timestamp[0..12].to_string(), ".".to_string(), timestamp[12..14].to_string())
 }
 
 /// Offloads the required fields from `stat` to parse timestamps
@@ -24,14 +28,13 @@ pub fn nix_stat_parser(
     let mut ctime = String::new();
 
     // Each line contains one timestamp
-    let mut index = 0;
+    let mut index: usize = 0;
     for line in stream.lines() {
-	if index == 0 {
-            ctime = nix_timestamp_parser(line);
-	} else if index == 1 {
-	    atime = nix_timestamp_parser(line);	    
-	} else if index == 2 {
-	    mtime = nix_timestamp_parser(line);
+	match index {
+	    0 => ctime = nix_timestamp_parser(line),
+	    1 => atime = nix_timestamp_parser(line),
+	    2 => mtime = nix_timestamp_parser(line),
+	    _ => {}
 	}
 	index = index + 1;
     }

--- a/src/core/parsers.rs
+++ b/src/core/parsers.rs
@@ -6,29 +6,13 @@ use super::fs::FileStat;
 pub fn nix_timestamp_parser(
     timestamp_str: &str
 ) -> String {
-    let mut fmt_time = String::with_capacity(15);
-    let mut start_parse: bool = false;
-    let mut seek_colon: bool = false;
-
-    for c in timestamp_str.chars() {
-        if c == ' ' { start_parse = true }
-        if start_parse {
-            match c {
-                '-' | ' ' => (),
-                ':' => {
-                    if seek_colon {
-                        fmt_time.push('.')
-                    }
-                    seek_colon = true;
-                },
-                '.' => break,
-                _ => fmt_time.push(c)
-            }
-        }
-    }
-
-    fmt_time
-} // hehe
+    timestamp_str[0..19]
+	.to_string()
+	.replace("-", "")
+	.replace(":", "")
+	.replace(" ", "")
+	.replace("'", "")
+}
 
 /// Offloads the required fields from `stat` to parse timestamps
 #[inline]
@@ -37,16 +21,20 @@ pub fn nix_stat_parser(
 ) -> FileStat {
     let mut atime = String::with_capacity(15);
     let mut mtime = String::with_capacity(15);
-    let ctime = String::new();
+    let mut ctime = String::new();
 
+    // Each line contains one timestamp
+    let mut index = 0;
     for line in stream.lines() {
-        if line.contains("Access") && !line.contains("Uid") {
-            atime = nix_timestamp_parser(line);
-        } else if line.contains("Modify") {
-            mtime = nix_timestamp_parser(line)
-        }
+	if index == 0 {
+            ctime = nix_timestamp_parser(line);
+	} else if index == 1 {
+	    atime = nix_timestamp_parser(line);	    
+	} else if index == 2 {
+	    mtime = nix_timestamp_parser(line);
+	}
+	index = index + 1;
     }
-
     FileStat {
         atime,
         mtime,


### PR DESCRIPTION
The timestamps of creation, access and modification were parsed
based on the raw output of the "/bin/stat" command.
This parsing was dependant of the text in the output, like the
"Access" word.
On non-English systems this parsing didn't work and the "touch" command
didn't show the timestamps.

The parameter "--printf='%w\n%x\n%y'" has been added to the "/bin/stat"
command so we only get the timestamps of creation, access and
modification. It simplifies the parsing rules and make the parsing
language-agnostic.

It's the same as in #5 except this time the order is valid in parsing.