### PR TITLE
Use the dates instead of timestamps in touch

### DIFF
--- a/src/core/parsers.rs
+++ b/src/core/parsers.rs
@@ -1,50 +1,24 @@
 use std::borrow::Cow;
 use super::fs::FileStat;
 
-/// Parses the date time format from `stat` to `[[CC]YY]MMDDhhmm[.ss]` format
-#[inline]
-pub fn nix_timestamp_parser(
-    timestamp_str: &str
-) -> String {
-    let mut fmt_time = String::with_capacity(15);
-    let mut start_parse: bool = false;
-    let mut seek_colon: bool = false;
-
-    for c in timestamp_str.chars() {
-        if c == ' ' { start_parse = true }
-        if start_parse {
-            match c {
-                '-' | ' ' => (),
-                ':' => {
-                    if seek_colon {
-                        fmt_time.push('.')
-                    }
-                    seek_colon = true;
-                },
-                '.' => break,
-                _ => fmt_time.push(c)
-            }
-        }
-    }
-
-    fmt_time
-} // hehe
-
 /// Offloads the required fields from `stat` to parse timestamps
 #[inline]
 pub fn nix_stat_parser(
     stream: Cow<'_, str>
 ) -> FileStat {
-    let mut atime = String::with_capacity(15);
-    let mut mtime = String::with_capacity(15);
-    let ctime = String::new();
+    let mut atime = String::with_capacity(35);
+    let mut mtime = String::with_capacity(35);
+    let mut ctime = String::with_capacity(35);
 
+    let mut index: usize = 0;
     for line in stream.lines() {
-        if line.contains("Access") && !line.contains("Uid") {
-            atime = nix_timestamp_parser(line);
-        } else if line.contains("Modify") {
-            mtime = nix_timestamp_parser(line)
-        }
+	match index {
+            0 => ctime = line.to_string(),
+            1 => atime = line.to_string(),
+            2 => mtime = line.to_string(),
+            _ => {}
+       }
+       index = index + 1;
     }
 
     FileStat {

--- a/src/start.rs
+++ b/src/start.rs
@@ -34,7 +34,7 @@ pub fn init() -> Result<()> {
                     let file_stats = FileSystem::file_nix_stat(filename);
 
                     let command = format!(
-                        "touch -a -t {} -m -t {} {}",
+                        "touch -a -d '{}' -m -d '{}' {}",
                         file_stats.atime,
                         file_stats.mtime,
                         filename


### PR DESCRIPTION
When the user gets a file using Moonwalk, the program gives it the
command to reset the timestamps of creation, modification and access
to their previous values.

When using the timestamps, the precision is no more than seconds, so
in the stat command the dates end with "000000000" for nanoseconds.
It is a hint that the timestamps have been changed.

To avoid this issue, the raw dates as returned by the stat command
are used now. This way, they can be given to the touch command and
the exact same date is reset.